### PR TITLE
Passing style prop to pickers

### DIFF
--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -19,6 +19,7 @@ const stylesFromProps = props => ({
   itemSpace: props.itemSpace,
   textColor: props.textColor,
   textSize: props.textSize,
+  style: props.style,
 });
 
 export default class DatePicker extends PureComponent {


### PR DESCRIPTION
```js
<Wheel.DatePicker
  mode="time"
  ...
  style={{ backgroundColor: '#fff' }} // doesn't work
/>
```

The PR fixes this