### PR TITLE
DatePicker android default month label look like DatePickerIOS.

### DIFF
--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -26,7 +26,7 @@ export default class DatePicker extends PureComponent {
   static propTypes = {
     labelUnit: PropTypes.shape({
       year: PropTypes.string,
-      month: PropTypes.string,
+      month: PropTypes.array,
       date: PropTypes.string,
     }),
     order: PropTypes.string,
@@ -42,7 +42,11 @@ export default class DatePicker extends PureComponent {
   };
 
   static defaultProps = {
-    labelUnit: { year: '', month: '', date: '' },
+    labelUnit: {
+      year: '',
+      month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+      date: ''
+    },
     order: 'D-M-Y',
     mode: 'date',
     maximumDate: moment().add(10, 'years').toDate(),
@@ -74,7 +78,7 @@ export default class DatePicker extends PureComponent {
     const maxYear = maximumDate.getFullYear();
 
     for (let i = 1; i <= 12; i += 1) {
-      this.state.monthRange.push({ value: i, label: `${i}${labelUnit.month}` });
+      this.state.monthRange.push({ value: i, label: `${labelUnit.month[i - 1]}` });
     }
 
     this.state.yearRange.push({ value: minYear, label: `${minYear}${labelUnit.year}` });


### PR DESCRIPTION
Support datePicker android default month label wheel look like DatePickerIOS.
![screen shot 2018-06-18 at 3 15 32 pm](https://user-images.githubusercontent.com/26365680/41525249-873d731a-730a-11e8-9b3b-3ebb3ebb670a.png)
